### PR TITLE
Add Logger accessor to Span

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
+vendor/
 composer.phar
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
       "role": "Developer"
     }
   ],
+  "require": {
+    "psr/log": "~1.0"
+  },
   "autoload": {
     "psr-4": {
       "OpenTracing\\": "src/"

--- a/src/OpenTracing/Span.php
+++ b/src/OpenTracing/Span.php
@@ -2,6 +2,8 @@
 
 namespace OpenTracing;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * Span represents a unit of work executed on behalf of a trace. Examples of
  * spans include a remote procedure call, or a in-process method call to a
@@ -13,6 +15,8 @@ namespace OpenTracing;
  */
 abstract class Span
 {
+    private $logger;
+
     /**
      * Sets or changes the operation name.
      *
@@ -121,6 +125,14 @@ abstract class Span
     public final function startChild($operationName, $tags = null, $startTime = null)
     {
         return $this->getTracer()->startSpan($operationName, $this, $tags, $startTime);
+    }
+
+    public final function getLogger() {
+        if ( is_null($this->logger) ) {
+            $this->logger = new SpanLogger($this);
+        }
+
+        return $this->logger;
     }
 
 }

--- a/src/OpenTracing/SpanLogger.php
+++ b/src/OpenTracing/SpanLogger.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OpenTracing;
+
+use Psr\Log\AbstractLogger;
+
+class SpanLogger extends AbstractLogger
+{
+    /**
+     * @var Span
+     */
+    private $span;
+
+    public function __construct(Span $span) {
+        $this->span = $span;
+    }
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     *
+     * @return null
+     */
+    public function log($level, $message, array $context = array())
+    {
+        $context['severity'] = $level;
+        $this->span->log(microtime(true), $message, $context);
+    }
+}


### PR DESCRIPTION
Reference implementations should be idiomatic in that language. I think the LoggerInterface is so popular we could add support for it in the core of the reference implementation.

I also thought about making the `Span` object itself implement those methods but we have a conflict between definition of OpenTracing's and LoggerInterface's `log` method.

I'd be happy to hear your opinion.
/cc @beberlei @bensigelman @yurishkuro
